### PR TITLE
fix: Pod e PodMonitor label to avoid scrapping by the ServiceMonitor

### DIFF
--- a/pt/src/day-7/README.md
+++ b/pt/src/day-7/README.md
@@ -465,14 +465,14 @@ kind: PodMonitor # tipo de recurso, no caso, um PodMonitor do Prometheus Operato
 metadata: # metadados do recurso
   name: nginx-podmonitor # nome do recurso
   labels: # labels do recurso
-    app: nginx # label que identifica o app
+    app: nginx-pod # label que identifica o app
 spec:
   namespaceSelector: # seletor de namespaces
     matchNames: # namespaces que serão monitorados
       - default # namespace que será monitorado
   selector: # seletor para identificar os pods que serão monitorados
     matchLabels: # labels que identificam os pods que serão monitorados
-      app: nginx # label que identifica o app que será monitorado
+      app: nginx-pod # label que identifica o app que será monitorado
   podMetricsEndpoints: # endpoints que serão monitorados
     - interval: 10s # intervalo de tempo entre as requisições
       path: /metrics # caminho para a requisição
@@ -490,7 +490,7 @@ kind: Pod # tipo de recurso, no caso, um Pod
 metadata: # metadados do recurso
   name: nginx-pod # nome do recurso
   labels: # labels do recurso
-    app: nginx # label que identifica o app
+    app: nginx-pod # label que identifica o app
 spec: # especificações do recursos
   containers: # containers do template 
     - name: nginx-container # nome do container

--- a/pt/src/day-7/files/nginx-pod.yaml
+++ b/pt/src/day-7/files/nginx-pod.yaml
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   name: nginx-pod
   labels:
-    app: nginx
+    app: nginx-pod
 spec:
   containers: # containers do template 
     - name: nginx-container # nome do container

--- a/pt/src/day-7/files/podmonitor.yaml
+++ b/pt/src/day-7/files/podmonitor.yaml
@@ -3,14 +3,14 @@ kind: PodMonitor # tipo de recurso, no caso, um PodMonitor do Prometheus Operato
 metadata: # metadados do recurso
   name: nginx-podmonitor # nome do recurso
   labels: # labels do recurso
-    app: nginx # label que identifica o app
+    app: nginx-pod # label que identifica o app
 spec:
   namespaceSelector: # seletor de namespaces
     matchNames: # namespaces que serão monitorados
       - default # namespace que será monitorado
   selector: # seletor para identificar os pods que serão monitorados
     matchLabels: # labels que identificam os pods que serão monitorados
-      app: nginx # label que identifica o app que será monitorado
+      app: nginx-pod # label que identifica o app que será monitorado
   podMetricsEndpoints: # endpoints que serão monitorados
     - interval: 10s # intervalo de tempo entre as requisições
       path: /metrics # caminho para a requisição


### PR DESCRIPTION
In the current documentation if we deploy together the ServiceMonitor and the PodMonitor we will have the targets mixed in Prometheus because the labels are the same.

Added specific labels for the podMonitor to make a new targer in Prometheus.